### PR TITLE
Add default case for switch statements

### DIFF
--- a/modules/runtime/src/main/java/org/shaolin/bmdp/json/XMLTokener.java
+++ b/modules/runtime/src/main/java/org/shaolin/bmdp/json/XMLTokener.java
@@ -227,6 +227,11 @@ public class XMLTokener extends JSONTokener
                         case '\'':
                             back();
                             return Boolean.TRUE;
+                        //missing default case
+                        default:
+                            // add default case
+                            break;
+
                     }
                 }
         }
@@ -323,6 +328,10 @@ public class XMLTokener extends JSONTokener
                         case '"':
                         case '\'':
                             throw syntaxError("Bad character in a name");
+                        //missing default case
+                        default:
+                            // add default case
+                            break;
                     }
                 }
         }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html