### PR TITLE
Missing default case for switch statements

### DIFF
--- a/modules/workflow/src/main/java/org/shaolin/bmdp/workflow/internal/FlowEngine.java
+++ b/modules/workflow/src/main/java/org/shaolin/bmdp/workflow/internal/FlowEngine.java
@@ -540,6 +540,11 @@ public class FlowEngine {
                 sessionService.rollbackSession(session);
                 stopTransaction(false, session);
                 break;
+	    //missing default case
+            default:
+            	// add default case
+            	break;
+
         }
     }
 


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html