### PR TITLE
Add default case for switch statements

### DIFF
--- a/modules/runtime/src/main/java/org/shaolin/bmdp/runtime/ddc/DataMonitor.java
+++ b/modules/runtime/src/main/java/org/shaolin/bmdp/runtime/ddc/DataMonitor.java
@@ -74,6 +74,11 @@ public class DataMonitor implements Watcher, StatCallback {
                 dead = true;
                 listener.closing(KeeperException.Code.SessionExpired);
                 break;
+            //missing default case
+            default:
+                // add default case
+                break;
+
             }
         } else {
             if (path != null && path.equals(znode)) {


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html