### PR TITLE
Add default case for switch statements

### DIFF
--- a/modules/javacc/src/main/java/org/shaolin/javacc/sql/parser/JavaCharStream.java
+++ b/modules/javacc/src/main/java/org/shaolin/javacc/sql/parser/JavaCharStream.java
@@ -51,6 +51,11 @@ public class JavaCharStream
        case 'f' :
        case 'F' :
           return 15;
+       //missing default case
+       default:
+            // add default case
+           break;
+
     }
 
     throw new java.io.IOException(); // Should never come here


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html